### PR TITLE
reduce function call in string parsing

### DIFF
--- a/src/Source.php
+++ b/src/Source.php
@@ -76,4 +76,25 @@ class Source
         }
         $this->current += strlen($expected);
     }
+
+    /**
+     * read givin length substring
+     *
+     * @param integer $length length to read
+     * @return string
+     * @throws UnserializeFailedException
+     */
+    public function read($length)
+    {
+        if ($length < 0) {
+            return $this->triggerError();
+        }
+
+        $result = substr($this->str, $this->current, $length);
+        if (strlen($result) !== $length) {
+            return $this->triggerError();
+        }
+        $this->current += $length;
+        return $result;
+    }
 }

--- a/src/StringParser.php
+++ b/src/StringParser.php
@@ -24,11 +24,7 @@ class StringParser implements ParserInterface
         list($length, $source) = $parser->parse($source);
 
         $source->consume(':"');
-        $result = '';
-        for ($i = 0; $i < $length; ++$i) {
-            $result .= $source->peek();
-            $source->next();
-        }
+        $result = $source->read($length);
         $source->consume('";');
 
         return array($result, $source);

--- a/test/SourceTest.php
+++ b/test/SourceTest.php
@@ -68,4 +68,40 @@ class SourceTest extends \PHPUnit_Framework_TestCase
         $source = new Source('hello');
         $source->consume('e');
     }
+
+    /**
+     * @covres ::read
+     */
+    public function testRead()
+    {
+        $source = new Source('abcdefg');
+        $actual = $source->read(5);
+        $this->assertSame('abcde', $actual);
+        $this->assertSame('f', $source->peek());
+    }
+
+    public function provideReadFailure()
+    {
+        return array(
+            array(
+                'input' => 'abc',
+                'length' => 5,
+            ),
+            array(
+                'input' => 'abc',
+                'length' => -1,
+            ),
+        );
+    }
+
+    /**
+     * @covers ::read
+     * @expectedException \xKerman\Restricted\UnserializeFailedException
+     * @dataProvider provideReadFailure
+     */
+    public function testReadFailure($input, $length)
+    {
+        $source = new Source($input);
+        $source->read($length);
+    }
 }


### PR DESCRIPTION
benchmark script is same as #18 .

result (before):
```
Running tests 2000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    6 ms                 0 B                
restricted-unserialize   1594 ms    26467 %      0 B                
Running tests 2000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    6 ms                 0 B                
restricted-unserialize   1577 ms    26183 %      0 B                
Running tests 2000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    6 ms                 0 B                
restricted-unserialize   1553 ms    25783 %      0 B                
Running tests 2000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    5 ms                 0 B                
restricted-unserialize   1581 ms    31520 %      0 B                
Running tests 2000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    6 ms                 0 B                
restricted-unserialize   1531 ms    25417 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   2305 ms    22950 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2422 ms    26811 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   11 ms                 0 B                
restricted-unserialize   2407 ms    21782 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   13 ms                 0 B                
restricted-unserialize   2354 ms    18008 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2381 ms    26356 %      0 B                
```

result(after):
```
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   2111 ms    17492 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   2029 ms    20190 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2050 ms    22678 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   1982 ms    21922 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   1983 ms    21933 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   1971 ms    19610 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   2011 ms    20010 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2022 ms    22367 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   1984 ms    21944 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    7 ms                 0 B                
restricted-unserialize   1990 ms    28329 %      0 B                
```

average time (%):
```
$ cat result-before.log |  grep -E '\d+ %' | gawk '{sum += $4; count += 1} END { print sum / count }'
25127.7
$ cat result-after.log |  grep -E '\d+ %' | gawk '{sum += $4; count += 1} END { print sum / count }'
21647.5
```