### PR TITLE
use regexp for speed up

### DIFF
--- a/src/FloatParser.php
+++ b/src/FloatParser.php
@@ -84,11 +84,7 @@ class FloatParser implements ParserInterface
      */
     private function parseDigits($source)
     {
-        $result = '';
-        while (ctype_digit($source->peek())) {
-            $result .= $source->peek();
-            $source->next();
-        }
+        $result = $source->match('/\A[0-9]*/');
         return array($result, $source);
     }
 

--- a/src/NumberStringParser.php
+++ b/src/NumberStringParser.php
@@ -21,19 +21,10 @@ class NumberStringParser implements ParserInterface
      */
     public function parse(Source $source)
     {
-        $parser = new OptionalSignParser();
-        list($result, $source) = $parser->parse($source);
-
-        $hasDigit = false;
-        while (ctype_digit($source->peek())) {
-            $hasDigit = true;
-            $result .= $source->peek();
-            $source->next();
-        }
-        if (!$hasDigit) {
+        $result = $source->match('/\A[+-]?[0-9]+/');
+        if ($result === '') {
             return $source->triggerError();
         }
-
         return array($result, $source);
     }
 }

--- a/src/Source.php
+++ b/src/Source.php
@@ -97,4 +97,21 @@ class Source
         $this->current += $length;
         return $result;
     }
+
+    /**
+     * return matching string for given regexp
+     *
+     * @param string $regexp Regular Expression for expected substring
+     * @return string
+     */
+    public function match($regexp)
+    {
+        $matched = preg_match($regexp, substr($this->str, $this->current), $matches);
+        if ($matched === 0 || $matched === false) {
+            return '';
+        }
+
+        $this->current += strlen($matches[0]);
+        return $matches[0];
+    }
 }

--- a/test/SourceTest.php
+++ b/test/SourceTest.php
@@ -104,4 +104,26 @@ class SourceTest extends \PHPUnit_Framework_TestCase
         $source = new Source($input);
         $source->read($length);
     }
+
+    /**
+     * @covers ::match
+     */
+    public function testMatch()
+    {
+        $source = new Source('abcde');
+        $result = $source->match('/\A\w{3}/');
+        $this->assertSame('abc', $result);
+        $this->assertSame('d', $source->peek());
+    }
+
+    /**
+     * @covers ::match
+     */
+    public function testMatchFailure()
+    {
+        $source = new Source('abcde12345');
+        $result = $source->match('/\A\d/');
+        $this->assertSame('', $result);
+        $this->assertSame('a', $source->peek());
+    }
 }


### PR DESCRIPTION
benchmark script is same as #18 .

# result (before):
```
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2025 ms    22400 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2022 ms    22367 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2018 ms    22322 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2022 ms    22367 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2095 ms    23178 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   2504 ms    24940 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   2077 ms    20670 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   2323 ms    23130 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   11 ms                 0 B                
restricted-unserialize   2341 ms    21182 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                    9 ms                 0 B                
restricted-unserialize   2096 ms    23189 %      0 B                
```

# result (after):
```
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   1792 ms    14833 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   1867 ms    15458 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   1795 ms    14858 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   1819 ms    15058 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   13 ms                 0 B                
restricted-unserialize   1799 ms    13738 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   1801 ms    14908 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   1827 ms    15125 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   14 ms                 0 B                
restricted-unserialize   1863 ms    13207 %      0 B                
Running tests 3000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   10 ms                 0 B                
restricted-unserialize   1433 ms    14230 %      0 B                
Running tests 4000 times.
Testing 1/2 : built-in
Testing 2/2 : restricted-unserialize

Test                        Time   Time (%)   Memory   Memory (%)   
built-in                   12 ms                 0 B                
restricted-unserialize   2016 ms    16700 %      0 B                
```

# average (%, lower is better)

* before: 22574.5
* after: 14811.5