### PR TITLE
use regexp submatch to reduce `substr` call

### DIFF
--- a/src/ArrayParser.php
+++ b/src/ArrayParser.php
@@ -37,7 +37,7 @@ class ArrayParser implements ParserInterface
         $this->integerParser = $integerParser;
         $this->stringParser = $stringParser;
         $this->parser = new TypeConvertParser(
-            new RegexpSubstringParser('/\Ga:[+]?[0-9]+:{/', 2, -2),
+            new RegexpParser('/\Ga:([+]?[0-9]+):{/'),
             new IntegerConverter()
         );
     }

--- a/src/ExpressionParser.php
+++ b/src/ExpressionParser.php
@@ -22,7 +22,7 @@ class ExpressionParser implements ParserInterface
         $this->parsers = array(
             'N' => new NullParser(),
             'b' => new TypeConvertParser(
-                new RegexpSubstringParser('/\Gb:[01];/', 2, 1),
+                new RegexpParser('/\Gb:([01]);/'),
                 new BooleanConverter()
             ),
             'i' => $integerParser,

--- a/src/IntegerParser.php
+++ b/src/IntegerParser.php
@@ -18,7 +18,7 @@ class IntegerParser implements ParserInterface
     public function __construct()
     {
         $this->parser = new TypeConvertParser(
-            new RegexpSubstringParser('/\Gi:[+-]?[0-9]+;/', 2, -1),
+            new RegexpParser('/\Gi:([+-]?[0-9]+);/'),
             new IntegerConverter()
         );
     }

--- a/src/RegexpParser.php
+++ b/src/RegexpParser.php
@@ -7,29 +7,19 @@ namespace xKerman\Restricted;
 /**
  * Parser that first process regexp match, and then substring the result
  */
-class RegexpSubstringParser implements ParserInterface
+class RegexpParser implements ParserInterface
 {
     /** @var string $regexp regexp for matching */
     private $regexp;
 
-    /** @var integer $start start position of substring */
-    private $start;
-
-    /** @var integer $length length of substring (see PHP `substr` manual) */
-    private $length;
-
     /**
      * constructor
      *
-     * @param string  $regexp regexp for matching
-     * @param integer $start  start position of substring
-     * @param integer $length length of substring
+     * @param string $regexp regexp for matching
      */
-    public function __construct($regexp, $start, $length)
+    public function __construct($regexp)
     {
         $this->regexp = $regexp;
-        $this->start = $start;
-        $this->length = $length;
     }
 
     /**
@@ -42,6 +32,6 @@ class RegexpSubstringParser implements ParserInterface
     public function parse(Source $source)
     {
         $result = $source->match($this->regexp);
-        return array(substr($result, $this->start, $this->length), $source);
+        return array($result, $source);
     }
 }

--- a/src/Source.php
+++ b/src/Source.php
@@ -112,6 +112,6 @@ class Source
         }
 
         $this->current += strlen($matches[0]);
-        return $matches[0];
+        return isset($matches[1]) ? $matches[1] : $matches[0];
     }
 }

--- a/src/StringParser.php
+++ b/src/StringParser.php
@@ -18,7 +18,7 @@ class StringParser implements ParserInterface
     public function __construct()
     {
         $this->parser = new TypeConvertParser(
-            new RegexpSubstringParser('/\Gs:[+]?[0-9]+:"/', 2, -2),
+            new RegexpParser('/\Gs:([+]?[0-9]+):"/'),
             new IntegerConverter()
         );
     }

--- a/test/RegexpParserTest.php
+++ b/test/RegexpParserTest.php
@@ -2,51 +2,47 @@
 
 namespace xKerman\Restricted\Test;
 
-use xKerman\Restricted\RegexpSubstringParser;
+use xKerman\Restricted\RegexpParser;
 use xKerman\Restricted\Source;
 
-class RegexpSubstringParserTest extends \PHPUnit_Framework_TestCase
+class RegexpParserTest extends \PHPUnit_Framework_TestCase
 {
     public function provideSuccessArgs()
     {
         return array(
             array(
                 'input' => 'b:1;',
-                'regexp' => '/\Gb:[10];/',
-                'start' => 2,
-                'length' => 1,
+                'regexp' => '/\Gb:([10]);/',
                 'expected' => '1',
             ),
             array(
                 'input' => 's:10:"aaaaaaaaaa";',
-                'regexp' => '/\Gs:[+]?[0-9]+:"/',
-                'start' => 2,
-                'length' => -2,
+                'regexp' => '/\Gs:([+]?[0-9]+):"/',
                 'expected' => '10',
             ),
         );
     }
 
     /**
-     * @covers \xKerman\Restricted\RegexpSubstringParser
+     * @covers \xKerman\Restricted\RegexpParser
      * @dataProvider provideSuccessArgs
      */
-    public function testParseSuccess($input, $regexp, $start, $length, $expected)
+    public function testParseSuccess($input, $regexp, $expected)
     {
         $source = new Source($input);
-        $parser = new RegexpSubstringParser($regexp, $start, $length);
+        $parser = new RegexpParser($regexp);
         list($actual, $source) = $parser->parse($source);
         $this->assertSame($expected, $actual);
     }
 
     /**
-     * @covers \xKerman\Restricted\RegexpSubstringParser
+     * @covers \xKerman\Restricted\RegexpParser
      * @expectedException \xKerman\Restricted\UnserializeFailedException
      */
     public function testParseFailure()
     {
         $source = new Source('b:0;');
-        $parser = new RegexpSubstringParser('/\Gb:1;/', 2, 1);
+        $parser = new RegexpParser('/\Gb:1;/');
         $parser->parse($source);
     }
 }

--- a/test/SourceTest.php
+++ b/test/SourceTest.php
@@ -118,6 +118,17 @@ class SourceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers ::match
+     */
+    public function testMatchSubpattern()
+    {
+        $source = new Source('1234hoge');
+        $result = $source->match('/\G1([0-9]+)/');
+        $this->assertSame('234', $result);
+        $this->assertSame('h', $source->peek());
+    }
+
+    /**
+     * @covers ::match
      * @expectedException \xKerman\Restricted\UnserializeFailedException
      */
     public function testMatchFailure()


### PR DESCRIPTION
benchmark script is same as #18 .

* result (before): 11991.6
* result (after): 11863.4