### PR TITLE
fix for string|array length parsing (close #40)

### DIFF
--- a/src/ArrayParser.php
+++ b/src/ArrayParser.php
@@ -53,7 +53,7 @@ class ArrayParser implements ParserInterface
      */
     public function parse(Source $source)
     {
-        $length = intval($source->match('/\Ga:([+]?[0-9]+):{/'), 10);
+        $length = intval($source->match('/\Ga:([0-9]+):{/'), 10);
 
         $result = array();
         for ($i = 0; $i < $length; ++$i) {

--- a/src/EscapedStringParser.php
+++ b/src/EscapedStringParser.php
@@ -21,7 +21,7 @@ class EscapedStringParser implements ParserInterface
      */
     public function parse(Source $source)
     {
-        $length = intval($source->match('/\GS:([+]?[0-9]+):"/'), 10);
+        $length = intval($source->match('/\GS:([0-9]+):"/'), 10);
         $result = array();
         for ($i = 0; $i < $length; ++$i) {
             $char = $source->read(1);

--- a/src/StringParser.php
+++ b/src/StringParser.php
@@ -21,7 +21,7 @@ class StringParser implements ParserInterface
      */
     public function parse(Source $source)
     {
-        $length = intval($source->match('/\Gs:([+]?[0-9]+):"/'), 10);
+        $length = intval($source->match('/\Gs:([0-9]+):"/'), 10);
         $result = $source->read($length);
         $source->consume('";', self::CLOSE_STRING_LENGTH);
 

--- a/test/ArrayParserTest.php
+++ b/test/ArrayParserTest.php
@@ -32,6 +32,10 @@ class ArrayParserTest extends \PHPUnit_Framework_TestCase
             'array length is negative' => array(
                 'input' => 'a:-1:{}',
             ),
+            'length contains plus sign' => array(
+                // see: https://github.com/php/php-src/commit/8522e2894edd52322148945261433e79a3ec3f88
+                'input' => 'a:+0:{}',
+            ),
             'array length is smaller than actual items' => array(
                 'input' => 'a:0:{i:0;s:1:"a";}',
             ),

--- a/test/EscapedStringParserTest.php
+++ b/test/EscapedStringParserTest.php
@@ -31,6 +31,10 @@ class EscapedStringParserTest extends \PHPUnit_Framework_TestCase
             'length is negative' => array(
                 'input' => 'S:-1:"";',
             ),
+            'length contains plus sign' => array(
+                // see: https://github.com/php/php-src/commit/8522e2894edd52322148945261433e79a3ec3f88
+                'input' => 'S:+1:"a";',
+            ),
             'no quote' => array(
                 'input' => 'S:1:a;',
             ),

--- a/test/StringParserTest.php
+++ b/test/StringParserTest.php
@@ -31,6 +31,10 @@ class StringParserTest extends \PHPUnit_Framework_TestCase
             'length is negative' => array(
                 'input' => 's:-1:"";',
             ),
+            'length contains plus sign' => array(
+                // see: https://github.com/php/php-src/commit/8522e2894edd52322148945261433e79a3ec3f88
+                'input' => 's:+1:"a";',
+            ),
             'no quote' => array(
                 'input' => 's:1:a;',
             ),


### PR DESCRIPTION
since plus sign for length is not permitted in PHP master (7.2)
https://github.com/php/php-src/commit/8522e2894edd52322148945261433e79a3ec3f88