### PR TITLE
fix to specify xdebug version for PHP5.5 test

### DIFF
--- a/docker/Dockerfile.5.5
+++ b/docker/Dockerfile.5.5
@@ -2,5 +2,5 @@ FROM nyanpass/php5.5:5.5-cli
 
 RUN apt-get update && \
     apt-get install unzip && \
-    pecl install xdebug && \
+    pecl install xdebug-2.5.5 && \
     docker-php-ext-enable xdebug


### PR DESCRIPTION
Travic CI build for PHP5.5 was failed
https://travis-ci.org/xKerman/restricted-unserialize/jobs/336817301

This pull request will fix the problem above.