### PR TITLE
specify tag for phpunit instead of branch for PHP5.2 build

### DIFF
--- a/docker/Dockerfile.5.2
+++ b/docker/Dockerfile.5.2
@@ -13,7 +13,7 @@ RUN cd /usr/local && \
     git clone git://github.com/sebastianbergmann/php-timer.git && \
     git clone git://github.com/sebastianbergmann/php-token-stream.git && \
     git clone git://github.com/sebastianbergmann/phpunit-mock-objects.git && \
-    cd phpunit && git checkout 3.6 && cd .. && \
+    cd phpunit && git checkout 3.6.12 && cd .. && \
     cd php-file-iterator && git checkout tags/1.3.2 && cd .. && \
     cd php-code-coverage && git checkout 1.1 && cd .. && \
     cd php-text-template && git checkout tags/1.1.1 && cd .. && \


### PR DESCRIPTION
fixes #83 